### PR TITLE
1841 replace broken link pointing to tagalog dictionary

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/content/word/create.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/word/create.jsp
@@ -168,7 +168,7 @@
                     <a href="https://translate.google.com/?sl=tl&tl=en&op=translate&text=<c:out value='${word.text}' />" target="_blank">Google Translate</a>
                 </li>
                 <li>
-                    <a href="https://www.tagaloglessons.com/words/<c:out value='${word.text}' />.php" target="_blank">TagalogLessons</a>
+                    <a href="https://www.tagalog.com/dictionary/<c:out value='${word.text}' />" target="_blank">TagalogLessons</a>
                 </li>
             </ol>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/content/word/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/content/word/edit.jsp
@@ -359,7 +359,7 @@
                     <a href="https://translate.google.com/?sl=tl&tl=en&op=translate&text=<c:out value='${word.text}' />" target="_blank">Google Translate</a>
                 </li>
                 <li>
-                    <a href="https://www.tagaloglessons.com/words/<c:out value='${word.text}' />.php" target="_blank">TagalogLessons</a>
+                    <a href="https://www.tagalog.com/dictionary/<c:out value='${word.text}' />" target="_blank">TagalogLessons</a>
                 </li>
             </ol>
         </div>


### PR DESCRIPTION
<!-- Which issue does this PR address? -->
Resolves the issue with the Tagalog links reported in the following issue: https://github.com/elimu-ai/webapp/issues/1841

<!-- Are there any key aspects of the implementation to highlight? -->
No, only the redirect links on the page have been updated.

<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
- The first step the reviewer should take is to set the content language to TGL.

- Next, the reviewer should access the words page. 
![image](https://github.com/user-attachments/assets/247e37c3-5bce-4788-9260-290fcac75324)

- The reviewer can access any word from the word list by simply clicking on it.
![image](https://github.com/user-attachments/assets/b8171f8e-fc09-43af-939b-e9740289b6d6)

-  After that, the reviewer should click on 'TagalogLessons' in the 'resources' modal available on the right.
![image](https://github.com/user-attachments/assets/5a933012-b387-43ea-8539-64fac3696801)

- After clicking, you should be redirected to the Tagalog dictionary page with the corresponding word that was displayed in the Elimu application.
![image](https://github.com/user-attachments/assets/f1eac8de-d235-403e-8193-c1de70a9f6c2)

<!-- If this PR affects the UI, please include screenshots demonstrating the changes. -->
No changes were made to the UI; however, I will attach screenshots of the Elimu and Tagalog pages.

![image](https://github.com/user-attachments/assets/b9b175e8-717a-4323-bc78-1f08a6c4be39)
![image](https://github.com/user-attachments/assets/b223f53f-c617-4e06-bd8a-cf177add6489)
